### PR TITLE
Improvements to the user feedback and interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1
+
+### Improvements
+
+-   [💎] Renaming `Custom Marker Icon URL` to `Custom marker URL` to follow Obsidian guidelines
+
 ## 1.1.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 -   [💎] Renaming `Custom Marker Icon URL` to `Custom marker URL` to follow Obsidian guidelines
+-   [💎] Showing a toast notice if the user uses an invalid combination of maki icon and custom marker url
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   [💎] Renaming `Custom Marker Icon URL` to `Custom marker URL` to follow Obsidian guidelines
 -   [💎] Showing a toast notice if the user uses an invalid combination of maki icon and custom marker url
+-   [💎] Showing a notice if the plugin has updated so that the user may check for new features
 
 ## 1.1.0
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "mapbox-location",
 	"name": "Mapbox Location Image",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"minAppVersion": "1.5.12",
 	"description": "Show a map inside your notes with a specific format.",
 	"author": "Aaron Czichon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mapbox-location",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Show a map inside your notes with a specific format.",
 	"main": "main.js",
 	"scripts": {

--- a/src/functions/version-hint.func.ts
+++ b/src/functions/version-hint.func.ts
@@ -1,0 +1,14 @@
+import { Notice, Plugin } from "obsidian";
+
+export const checkVersionUpdate = async (plugin: Plugin) => {
+	const data = await plugin.loadData();
+	if (data && data.version === plugin.manifest.version) return;
+
+	new Notice(
+		`Mapbox plugin has been updated to version ${plugin.manifest.version}. Check the changelog for more information and new features.`,
+		5000,
+	);
+
+	data.version = plugin.manifest.version;
+	await plugin.saveData(data);
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Notice, Plugin } from "obsidian";
 import { processCodeBlock } from "./functions/process-code.func";
+import { checkVersionUpdate } from "./functions/version-hint.func";
 import { LocationSettingTab } from "./settings/plugin-settings.tab";
 import {
 	DEFAULT_SETTINGS,
@@ -19,6 +20,8 @@ export default class MapboxPlugin extends Plugin {
 		);
 
 		this.addSettingTab(new LocationSettingTab(this.app, this));
+
+		await checkVersionUpdate(this);
 	}
 
 	public processLocationCodeBlock = (source: string, el: HTMLElement) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,6 +68,12 @@ export default class MapboxPlugin extends Plugin {
 		}
 		const markerUrl = this.getMarkerUrl(codeMarker, makiIcon);
 
+		if (markerUrl && makiIcon) {
+			this.showNotice(
+				"Both marker URL and Maki icon are set. Setting both is not a valid combination.",
+			);
+		}
+
 		const mapStyle = style || this.settings.mapStyle;
 
 		const imageUrl = `https://api.mapbox.com/styles/v1/mapbox/${mapStyle}/static/${markerUrl}(${longitude},${latitude})/${longitude},${latitude},14/800x400?access_token=${mapboxAccessToken}`;

--- a/src/settings/plugin-settings.control.ts
+++ b/src/settings/plugin-settings.control.ts
@@ -24,7 +24,7 @@ export const markerUrlSetting = (
 	plugin: MapboxPlugin,
 ) => {
 	new Setting(containerEl)
-		.setName("Custom Marker Icon URL")
+		.setName("Custom marker URL")
 		.setDesc(
 			"You can define a custom marker icon by providing a URL which will be used as default marker icon",
 		)


### PR DESCRIPTION
# Description

This PR brings some improvements to the feedback that is given to the user e.g. on invalid settings combinations and on version updates.

# Changes

Changed the naming of the setting for marker URL:
<img width="364" alt="image" src="https://github.com/aaronczichon/obsidian-location-plugin/assets/5436608/34f7beea-804b-4361-8204-19c78131d9e6">

Showing a toast on an invalid setting combination:
<img width="400" alt="image" src="https://github.com/aaronczichon/obsidian-location-plugin/assets/5436608/200e729b-a749-4488-9b0f-ef716942e2df">

# Issues
- closes #24 
- closes #25
- closes #26