### PR TITLE
Added support for custom zoom settings

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -92,11 +92,11 @@ longitude: -63.57530151565183
 zoom: 1
 ```
 
-Zoom value 10 (default):
+Zoom value 14 (default):
 ```location
 latitude: 44.64266326577057
 longitude: -63.57530151565183
-zoom: 10
+zoom: 14
 ```
 
 Zoom value 20 (default):

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -78,3 +78,30 @@ Following values for the code block are supported:
 **Hint**  
 Maki icon can only defined in the code block and can't be defined globally. If no custom marker or maki icon is defined, the map falls back to the default marker icon (a home icon).  
 If you have defined a custom icon URL (in plugin settings or in your code block) the defined maki icon is ignored.
+
+### Changing the zoom
+
+There are two options to change the zoom. You can either change the global setting in the plugin settings, which will then be applied to every map generated. Or, you can set a custom zoom for a specific map - this will override the global zoom.
+
+If you want a custom zoom for a specific map, you can add a `zoom` field to the code block. The value of the field should be a number between 1 (maximum zoomed out) and 20 (maximum zoomed in).
+
+Zoom value 1:
+```location
+latitude: 44.64266326577057
+longitude: -63.57530151565183
+zoom: 1
+```
+
+Zoom value 10 (default):
+```location
+latitude: 44.64266326577057
+longitude: -63.57530151565183
+zoom: 10
+```
+
+Zoom value 20 (default):
+```location
+latitude: 44.64266326577057
+longitude: -63.57530151565183
+zoom: 20
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mapbox-location",
-	"version": "1.0.3",
+	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mapbox-location",
-			"version": "1.0.3",
+			"version": "1.1.1",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"mapbox-gl": "^2.15.0"

--- a/src/functions/process-code.func.ts
+++ b/src/functions/process-code.func.ts
@@ -6,6 +6,7 @@ export const processCodeBlock = (source: string) => {
 	const markerUrl = findMarkerUrl(rows);
 	const makiIcon = findMarkerIcon(rows);
 	const mapStyle = findMapStyle(rows);
+	const mapZoom = findMapZoom(rows);
 
 	return {
 		latitude,
@@ -13,6 +14,7 @@ export const processCodeBlock = (source: string) => {
 		markerUrl,
 		makiIcon,
 		mapStyle,
+		mapZoom
 	};
 };
 
@@ -56,3 +58,10 @@ const findMapStyle = (rows: string[]) => {
 		mapStyle = mapStyle.toLocaleLowerCase().replace("style:", "").trim();
 	return mapStyle;
 };
+
+var findMapZoom = (rows) => {
+	let mapZoom = rows.find((l) => l.toLowerCase().startsWith("zoom:"));
+	if (mapZoom)
+	  mapZoom = mapZoom.toLocaleLowerCase().replace("zoom:", "").trim();
+	return mapZoom;
+  };

--- a/src/functions/process-code.func.ts
+++ b/src/functions/process-code.func.ts
@@ -59,7 +59,7 @@ const findMapStyle = (rows: string[]) => {
 	return mapStyle;
 };
 
-var findMapZoom = (rows) => {
+const findMapZoom = (rows: string[]) => {
 	let mapZoom = rows.find((l) => l.toLowerCase().startsWith("zoom:"));
 	if (mapZoom)
 	  mapZoom = mapZoom.toLocaleLowerCase().replace("zoom:", "").trim();

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ export default class MapboxPlugin extends Plugin {
 		codeMarker: string = "",
 		makiIcon: string = "",
 		style: string = "",
-		zoom: string,
+		zoom: string = "",
 	): string => {
 		const mapboxAccessToken = this.settings.mapboxToken;
 		if (!mapboxAccessToken) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ export default class MapboxPlugin extends Plugin {
 				extractedData.markerUrl,
 				extractedData.makiIcon,
 				extractedData.mapStyle,
+				extractedData.mapZoom,
 			);
 
 			const imageElement = document.createElement("img");
@@ -61,6 +62,7 @@ export default class MapboxPlugin extends Plugin {
 		codeMarker: string = "",
 		makiIcon: string = "",
 		style: string = "",
+		zoom: string,
 	): string => {
 		const mapboxAccessToken = this.settings.mapboxToken;
 		if (!mapboxAccessToken) {
@@ -79,7 +81,9 @@ export default class MapboxPlugin extends Plugin {
 
 		const mapStyle = style || this.settings.mapStyle;
 
-		const imageUrl = `https://api.mapbox.com/styles/v1/mapbox/${mapStyle}/static/${markerUrl}(${longitude},${latitude})/${longitude},${latitude},14/800x400?access_token=${mapboxAccessToken}`;
+		const mapZoom = zoom || this.settings.mapZoom;
+
+		const imageUrl = `https://api.mapbox.com/styles/v1/mapbox/${mapStyle}/static/${markerUrl}(${longitude},${latitude})/${longitude},${latitude},${mapZoom}/800x400?access_token=${mapboxAccessToken}`;
 
 		return imageUrl;
 	};

--- a/src/settings/plugin-settings.control.ts
+++ b/src/settings/plugin-settings.control.ts
@@ -103,3 +103,25 @@ export const markerColorSetting = (
 				}),
 		);
 };
+
+export const mapZoomSetting = (
+	containerEl: HTMLElement,
+	plugin: MapboxPlugin,
+) => {
+	new Setting(containerEl)
+		.setName("Map zoom")
+		.setDesc("Set the default zoom for each map image.")
+		.addDropdown((text) =>
+			text
+				.addOption("20", "20 - closest")
+				.addOption("15", "15")
+				.addOption("10", "10")
+				.addOption("5", "5")
+				.addOption("1", "1 - furthest")
+				.setValue(plugin.settings.mapZoom)
+				.onChange(async (value) => {
+					plugin.settings.mapZoom = value;
+					await plugin.saveSettings();
+				}),
+		);
+};

--- a/src/settings/plugin-settings.tab.ts
+++ b/src/settings/plugin-settings.tab.ts
@@ -6,6 +6,7 @@ import {
 	markerColorSetting,
 	markerSizeSetting,
 	markerUrlSetting,
+	mapZoomSetting,
 } from "./plugin-settings.control";
 
 export class LocationSettingTab extends PluginSettingTab {
@@ -26,5 +27,6 @@ export class LocationSettingTab extends PluginSettingTab {
 		markerSizeSetting(containerEl, this.plugin);
 		markerColorSetting(containerEl, this.plugin);
 		markerUrlSetting(containerEl, this.plugin);
+		mapZoomSetting(containerEl, this.plugin);
 	}
 }

--- a/src/settings/plugin-settings.types.ts
+++ b/src/settings/plugin-settings.types.ts
@@ -4,6 +4,7 @@ export interface LocationPluginSettings {
 	markerColor: string;
 	markerUrl: string;
 	mapStyle: string;
+	mapZoom: string;
 }
 
 export const DEFAULT_SETTINGS: Partial<LocationPluginSettings> = {
@@ -12,4 +13,5 @@ export const DEFAULT_SETTINGS: Partial<LocationPluginSettings> = {
 	markerColor: "ff0000",
 	markerUrl: "",
 	mapStyle: "streets-v12",
+	mapZoom: "10"
 };

--- a/src/settings/plugin-settings.types.ts
+++ b/src/settings/plugin-settings.types.ts
@@ -13,5 +13,5 @@ export const DEFAULT_SETTINGS: Partial<LocationPluginSettings> = {
 	markerColor: "ff0000",
 	markerUrl: "",
 	mapStyle: "streets-v12",
-	mapZoom: "10"
+	mapZoom: "14"
 };


### PR DESCRIPTION
Global zoom setting able to be set in plugin settings (kept to increments of 5 for ease of use).
Zoom settings able to be changed in-line for specific maps using new 'zoom' field, preferred over global.

New value submitted into API request. Tested with all other functionality and seems to work.

DOCUMENTATION.md updated with suggestions

Thanks for your work!