### PR TITLE
Feature: additional syntax & reverse coordinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   [🚀] Added option to search for a location inside location block (@nehnehneh)
 -   [🚀] Supporting alternate syntax using [latitude, longitude] array (#18)
+-   [🚀] Allow reverse order of coordinates (e.g. if copied from Google Maps) via setting (#21)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   [🚀] Added option to search for a location inside location block (@nehnehneh)
+-   [🚀] Supporting alternate syntax using [latitude, longitude] array (#18)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   [⚙️] ci: added step to check commit messages on build workflow
 
+### Fixed
+
+-   [🐛] Fixed issue with custom marker icon not being displayed correctly
+
 ## [1.2.0] - 2024-07-26
 
 ### Added

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -28,6 +28,13 @@ Longitude: -63.57530151565183
 It doesn't matter if you provide the latitude or longitude first. The plugin will recognize the values and generate the map image.  
 Also it's not relevant if you write `Latitude` or `latitude` and `Longitude` or `longitude`.
 
+You can also provide the coordinates in one line using the array syntax like this:
+\```location  
+[44.64266326577057, -63.57530151565183]  
+\```
+
+-> Make sure that this syntax uses [latitude, longitude] order.
+
 #### Using search phrase
 
 If you provide a search phrase the plugin will fetch the most relevant result and generate the map image.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -145,7 +145,7 @@ zoom: 1
 
 ### Reverse order of coordinates
 
-The default order of coordinates is `latitude, longitude`. If you have copied coordinates from Google Maps or another source where the order is `longitude, latitude`, you can set the plugin to use the reverse order.   
+The default order of coordinates is `latitude, longitude`. If you have copied coordinates from Google Maps or another source where the order is `longitude, latitude`, you can set the plugin to use the reverse order.  
 This can be done using the toggle in the plugin settings.
 
 ![Screenshot map with zoom setting 1](./docs/zoom-setting-1.png)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -143,6 +143,11 @@ longitude: -63.57530151565183
 zoom: 1
 ```
 
+### Reverse order of coordinates
+
+The default order of coordinates is `latitude, longitude`. If you have copied coordinates from Google Maps or another source where the order is `longitude, latitude`, you can set the plugin to use the reverse order.   
+This can be done using the toggle in the plugin settings.
+
 ![Screenshot map with zoom setting 1](./docs/zoom-setting-1.png)
 
 Zoom value 14 (default):

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Latitude: 44.64266326577057
 Longitude: -63.57530151565183  
 \```
 
+Or
+\```location  
+[44.64266326577057, -63.57530151565183]  
+\```
+
 This is how it looks rendered:
 ![Screenshot of obsidian with rendered location image](/docs/rendered.png)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "mapbox-location",
 	"name": "Mapbox Location Image",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"minAppVersion": "1.5.12",
 	"description": "Show a map inside your notes with a specific format.",
 	"author": "Aaron Czichon",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mapbox-location",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mapbox-location",
-			"version": "1.2.0",
+			"version": "1.3.0",
 			"license": "GPL-3.0-only",
 			"dependencies": {
 				"@obsidianjs/http-request": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mapbox-location",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Show a map inside your notes with a specific format.",
 	"main": "main.js",
 	"scripts": {

--- a/src/functions/map.func.ts
+++ b/src/functions/map.func.ts
@@ -1,0 +1,51 @@
+import { LocationPluginSettings } from "../settings/plugin-settings.types";
+
+export const getMarkerUrl = (
+	codeMarker: string,
+	makiIcon: string,
+	settings: LocationPluginSettings,
+) => {
+	// If a marker URL is set in code block use it
+	if (codeMarker) return `url-${encodeURIComponent(codeMarker)}`;
+	// If a marker URL is set in settings use it
+	if (settings.markerUrl)
+		return `url-${encodeURIComponent(settings.markerUrl)}`;
+
+	// if no marker URL is set at all, use the default
+	return `pin-${settings.markerSize}-${makiIcon || "home"}+${settings.markerColor}`;
+};
+
+/**
+ * With the given parameters a static map with be generated as image and the URL
+ * of it will be returned.
+ * @param latitude Latitude of the location
+ * @param longitude Longitude of the location
+ * @param codeMarker URL of the marker
+ * @param makiIcon Name of the maki icon which should be used as a marker
+ * @param style Mapbox style which should be used
+ * @param zoom Level of zoom on the map
+ * @returns URL of the static map image
+ */
+export const getStaticMapImageUrl = (
+	settings: LocationPluginSettings,
+	latitude: string = "",
+	longitude: string = "",
+	codeMarker: string = "",
+	makiIcon: string = "",
+	style: string = "",
+	zoom: string = "",
+): string => {
+	const markerUrl = getMarkerUrl(codeMarker, makiIcon, settings);
+
+	if (codeMarker && makiIcon) {
+		throw "Both marker URL and Maki icon are set. Setting both is not a valid combination.";
+	}
+
+	const mapStyle = style || settings.mapStyle;
+
+	const mapZoom = zoom || settings.mapZoom;
+
+	const imageUrl = `https://api.mapbox.com/styles/v1/mapbox/${mapStyle}/static/${markerUrl}(${longitude},${latitude})/${longitude},${latitude},${mapZoom}/800x400?access_token=${settings.mapboxToken}`;
+
+	return imageUrl;
+};

--- a/src/functions/process-code.func.ts
+++ b/src/functions/process-code.func.ts
@@ -1,13 +1,16 @@
 export const processCodeBlock = (source: string) => {
 	const rows = source.split("\n");
 
-	const latitude = findLatitude(rows);
-	const longitude = findLongitude(rows);
+	let latitude = findLatitude(rows);
+	let longitude = findLongitude(rows);
 	const markerUrl = findMarkerUrl(rows);
 	const makiIcon = findMarkerIcon(rows);
 	const mapStyle = findMapStyle(rows);
 	const mapZoom = findMapZoom(rows);
 	const searchQuery = findSearchQuery(rows);
+	const latLong = findLatitudeAndLongitude(rows);
+	latitude = latLong ? latLong[0] : latitude;
+	longitude = latLong ? latLong[1] : longitude;
 
 	return {
 		latitude,
@@ -18,6 +21,17 @@ export const processCodeBlock = (source: string) => {
 		mapZoom,
 		searchQuery,
 	};
+};
+
+const findLatitudeAndLongitude = (rows: string[]) => {
+	const regex = /^\[\s*(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)\s*\]$/;
+	let latLong = rows.find((l) => regex.test(l.toLowerCase()));
+	if (latLong) {
+		const match = latLong.match(regex);
+		if (match) {
+			return [match[1], match[3]];
+		}
+	}
 };
 
 const findLatitude = (rows: string[]) => {

--- a/src/functions/process-location-search.func.ts
+++ b/src/functions/process-location-search.func.ts
@@ -1,15 +1,16 @@
-import { requestUrl, SuggestModal } from "obsidian";
-import { LocationSettingTab } from "../settings/plugin-settings.tab";
-import { setMaxIdleHTTPParsers } from "http";
+import { requestUrl } from "obsidian";
 
-export async function processLocationSearch(
+export const processLocationSearch = async (
 	query: string = "",
 	accessToken: string,
-) {
+) => {
 	const mapbox_id: string = await hitSuggestAPI(query, accessToken);
 	const result: any = await hitRetrieveAPI(mapbox_id, accessToken);
-	return result.json.features[0].properties;
-}
+	const properties = result.json.features[0].properties;
+	const latitude = properties.coordinates.latitude;
+	const longitude = properties.coordinates.longitude;
+	return [latitude, longitude, properties.full_address];
+};
 
 // query the /suggest search API endpoint and retrieve the first result from the suggested locations
 // returns the mapbox_id

--- a/src/functions/process-location-search.func.ts
+++ b/src/functions/process-location-search.func.ts
@@ -14,19 +14,19 @@ export const processLocationSearch = async (
 
 // query the /suggest search API endpoint and retrieve the first result from the suggested locations
 // returns the mapbox_id
-async function hitSuggestAPI(query: string, accessToken: string) {
+const hitSuggestAPI = async (query: string, accessToken: string) => {
 	const suggestUrl = `https://api.mapbox.com/search/searchbox/v1/suggest?q=${query}&language=en&limit=1&session_token=00000000-0000-0000-0000-000000000000&access_token=${accessToken}`;
 	const suggestObject = await requestUrl(suggestUrl);
 	const result = await suggestObject.json;
 	const mapbox_id = result.suggestions[0].mapbox_id;
 	console.log("***mapbox_id found***" + mapbox_id);
 	return mapbox_id;
-}
+};
 
 // use the mapbox_id to query the /retrieve API endpoint for the location
 // returns object for the location
-async function hitRetrieveAPI(mapbox_id: string, accessToken: string) {
+const hitRetrieveAPI = async (mapbox_id: string, accessToken: string) => {
 	const retrieveUrl = `https://api.mapbox.com/search/searchbox/v1/retrieve/${mapbox_id}?session_token=00000000-0000-0000-0000-000000000000&access_token=${accessToken}`;
 	const retrieveObject = await requestUrl(retrieveUrl);
 	return retrieveObject;
-}
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,13 @@ export default class MapboxPlugin extends Plugin {
 				long = longitude.toString();
 				address = fullAddress;
 			}
+			// if we need to flip the order of the coordinates
+			// then we need to do it before rendering the image
+			if (this.settings.reverseOrder) {
+				const temp = lat;
+				lat = long;
+				long = temp;
+			}
 			this.addStaticImageToContainer(
 				this.settings,
 				extractedData,

--- a/src/settings/plugin-settings.control.ts
+++ b/src/settings/plugin-settings.control.ts
@@ -1,4 +1,4 @@
-import { Setting } from "obsidian";
+import { Notice, Setting } from "obsidian";
 import MapboxPlugin from "../main";
 
 export const apiTokenSetting = (
@@ -122,6 +122,28 @@ export const mapZoomSetting = (
 				.onChange(async (value) => {
 					plugin.settings.mapZoom = value;
 					await plugin.saveSettings();
+				}),
+		);
+};
+
+export const coordinatesReverseOrder = (
+	containerEl: HTMLElement,
+	plugin: MapboxPlugin,
+) => {
+	new Setting(containerEl)
+		.setName("Reverse order")
+		.setDesc(
+			"If you copy coordinates in a different order (e.g. from Google Maps) you can automatically reverse them.",
+		)
+		.addToggle((reverse) =>
+			reverse
+				.setValue(plugin.settings.reverseOrder)
+				.onChange(async (value) => {
+					plugin.settings.reverseOrder = value;
+					await plugin.saveSettings();
+					new Notice(
+						"Coordinates order reversed. This affects all your location code blocks.",
+					);
 				}),
 		);
 };

--- a/src/settings/plugin-settings.tab.ts
+++ b/src/settings/plugin-settings.tab.ts
@@ -2,11 +2,12 @@ import { App, PluginSettingTab } from "obsidian";
 import MapboxPlugin from "../main";
 import {
 	apiTokenSetting,
+	coordinatesReverseOrder,
 	mapStyleSetting,
+	mapZoomSetting,
 	markerColorSetting,
 	markerSizeSetting,
 	markerUrlSetting,
-	mapZoomSetting,
 } from "./plugin-settings.control";
 
 export class LocationSettingTab extends PluginSettingTab {
@@ -28,5 +29,6 @@ export class LocationSettingTab extends PluginSettingTab {
 		markerColorSetting(containerEl, this.plugin);
 		markerUrlSetting(containerEl, this.plugin);
 		mapZoomSetting(containerEl, this.plugin);
+		coordinatesReverseOrder(containerEl, this.plugin);
 	}
 }

--- a/src/settings/plugin-settings.types.ts
+++ b/src/settings/plugin-settings.types.ts
@@ -5,6 +5,7 @@ export interface LocationPluginSettings {
 	markerUrl: string;
 	mapStyle: string;
 	mapZoom: string;
+	reverseOrder: boolean;
 }
 
 export const DEFAULT_SETTINGS: Partial<LocationPluginSettings> = {
@@ -14,4 +15,5 @@ export const DEFAULT_SETTINGS: Partial<LocationPluginSettings> = {
 	markerUrl: "",
 	mapStyle: "streets-v12",
 	mapZoom: "15",
+	reverseOrder: false,
 };


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes which issue is fixed / addressed. Please also include technical details about the implementation if required. -->
This PRs introduces some changes to the coordination handling.
You can now use the array syntax for coordinates like this:
```
[44.64266326577057, -63.57530151565183]
```

And you can reverse the order of the coordinates give to mapbox. This is useful as the order is different between mapbox and google maps. 
So if you often copy coordinates from google maps and don't want to re-arrange the coordinates by yourself just enable the automatic reverse in the settings:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/5abcf04a-1fb3-4377-9145-05a9497b65ae">


## Completes

<!-- Please link your issues numbers here -->
- closes #18 
- closes #21 

## Type of change

Please select an option

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation update
-   [ ] Other (please provide a description below)

## Testing Instructions

Please provide testing instructions for the reviewer here

-   [x] Manual testing (Please provide the testing instructions)
-   [ ] Automated testing

## Screenshots

<!-- Please provide any screenshots here -->

## Review Checklist

-   [x] Code follows style & code guidelines
-   [x] Has linked issue
-   [x] Pull request includes description
-   [x] Version and changelog were updated
-   [x] Testing Instructions are provided
-   [x] Tests are verified
-   [x] Commits follow our [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines
