### PR TITLE
Improvement: style names for code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2025-05-22
+
+### Improvement
+
+- [💎] Code blocks now support styles according to documentation (not mapbox strings) #51
+
 ## [2.0.1] - 2025-05-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.2] - 2025-05-22
 
-### Improvement
+### Fixed
 
 - [💎] Code blocks now support styles according to documentation (not mapbox strings) #51
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "mapbox-location",
 	"name": "Mapbox Location Image",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"minAppVersion": "1.5.12",
 	"description": "Show a map inside your notes with a specific format.",
 	"author": "Aaron Czichon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mapbox-location",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "Show a map inside your notes with a specific format.",
 	"main": "main.js",
 	"scripts": {

--- a/src/exctractors/row-extractor.func.ts
+++ b/src/exctractors/row-extractor.func.ts
@@ -1,6 +1,8 @@
 // This file is used to define functions which extracting specific information from the rows
 // of a code block. The extracted information is then used to configure the map settings.
 
+import { mapboxStyles } from '../functions/style.func';
+
 export const findLatitudeAndLongitude = (rows: string[]) => {
 	const regex = /^\[\s*(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)\s*\]$/;
 	let latLong = rows.find((l) => regex.test(l.toLowerCase()));
@@ -38,7 +40,10 @@ export const findMarkerIcon = (rows: string[]) => {
 
 export const findMapStyle = (rows: string[]) => {
 	let mapStyle = rows.find((l) => l.toLowerCase().startsWith('style:'));
-	if (mapStyle) mapStyle = mapStyle.toLocaleLowerCase().replace('style:', '').trim();
+	if (mapStyle) {
+		mapStyle = mapStyle.toLocaleLowerCase().replace('style:', '').trim();
+		mapStyle = mapboxStyles.find((s) => s.blockName === mapStyle)?.mapboxName;
+	}
 	return mapStyle;
 };
 

--- a/src/functions/style.func.ts
+++ b/src/functions/style.func.ts
@@ -1,0 +1,58 @@
+export type MapboxStyle = {
+	mapboxName: string;
+	blockName: string;
+	settingsName: string;
+};
+
+export const mapboxStyles: MapboxStyle[] = [
+	{
+		mapboxName: 'streets-v12',
+		blockName: 'streets',
+		settingsName: 'Streets',
+	},
+	{
+		mapboxName: 'outdoors-v12',
+		blockName: 'outdoors',
+		settingsName: 'Outdoors',
+	},
+	{
+		mapboxName: 'light-v11',
+		blockName: 'light',
+		settingsName: 'Light',
+	},
+	{
+		mapboxName: 'dark-v11',
+		blockName: 'dark',
+		settingsName: 'Dark',
+	},
+	{
+		mapboxName: 'satellite-v9',
+		blockName: 'satellite',
+		settingsName: 'Satellite',
+	},
+	{
+		mapboxName: 'satellite-streets-v12',
+		blockName: 'satellite-streets',
+		settingsName: 'Satellite Streets',
+	},
+	{
+		mapboxName: 'navigation-day-v1',
+		blockName: 'navigation-day',
+		settingsName: 'Navigation Day',
+	},
+	{
+		mapboxName: 'navigation-night-v1',
+		blockName: 'navigation-night',
+		settingsName: 'Navigation Night',
+	},
+];
+
+/**
+ * Get the Mapbox style name from the user-defined style.
+ * @param style The user-defined style.
+ */
+export const getMapboxStyle = (style: string) => {
+	const mapboxStyle = mapboxStyles.find((s) => s.blockName === style);
+	if (mapboxStyle) return mapboxStyle.mapboxName;
+	return 'streets-v12';
+};

--- a/src/settings/plugin-settings.control.ts
+++ b/src/settings/plugin-settings.control.ts
@@ -1,4 +1,5 @@
 import { Notice, Setting } from 'obsidian';
+import { mapboxStyles } from '../functions/style.func';
 import MapboxPlugin from '../main';
 
 export const apiTokenSetting = (
@@ -59,19 +60,19 @@ export const mapStyleSetting = (
 	plugin: MapboxPlugin,
 	callback: Function,
 ) => {
+	const stylesAsRecords = mapboxStyles.reduce(
+		(acc, style) => {
+			acc[style.mapboxName] = style.settingsName;
+			return acc;
+		},
+		{} as Record<string, string>,
+	);
 	new Setting(containerEl)
 		.setName('Default map style')
 		.setDesc('Select the default style which is used for your maps.')
 		.addDropdown((text) =>
 			text
-				.addOption('streets-v12', 'Streets')
-				.addOption('outdoors-v12', 'Outdoors')
-				.addOption('light-v11', 'Light')
-				.addOption('dark-v11', 'Dark')
-				.addOption('satellite-v9', 'Satellite')
-				.addOption('satellite-streets-v12', 'Satellite Streets')
-				.addOption('navigation-day-v1', 'Navigation Day')
-				.addOption('navigation-night-v1', 'Navigation Night')
+				.addOptions(stylesAsRecords)
 				.setValue(plugin.settings.mapStyle)
 				.onChange(async (value) => callback(value)),
 		);


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes which issue is fixed / addressed. Please also include technical details about the implementation if required. -->
Until now you had to use mapbox style names like `streets-v12` to make them work in code blocks. This is now changed to match documentation. You can now use e.g. `streets` and it will be mapped internally.

## Completes

<!-- Please link your issues numbers here -->
- closes #51

## Type of change

Please select an option

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please provide a description below)

## Testing Instructions

Please provide testing instructions for the reviewer here

- [x] Manual testing (Please provide the testing instructions)
- [ ] Automated testing

## Screenshots

<!-- Please provide any screenshots here -->
<img width="284" alt="image" src="https://github.com/user-attachments/assets/7b804a72-ecfc-4689-9bae-83dc908ef933" />


## Review Checklist

- [x] Code follows style & code guidelines
- [x] Has linked issue
- [x] Pull request includes description
- [x] Version and changelog were updated
- [x] Testing Instructions are provided
- [x] Tests are verified
- [x] Commits follow our [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines
